### PR TITLE
Remove duplicate definition of `args` vector.

### DIFF
--- a/drogon_ctl/main.cc
+++ b/drogon_ctl/main.cc
@@ -19,13 +19,13 @@
 
 int main(int argc, char *argv[])
 {
+    std::vector<std::string> args;
     if (argc < 2)
     {
-        std::vector<std::string> args = {"help"};
+        args = {"help"};
         exeCommand(args);
         return 0;
     }
-    std::vector<std::string> args;
     for (int i = 1; i < argc; ++i)
     {
         args.push_back(argv[i]);


### PR DESCRIPTION
Removed duplicate definition of the variable `args` which could be defined in the first line rather than defining once in the if scope and once in the main function.